### PR TITLE
Updates for handling labels for nested peers

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -765,27 +765,14 @@ internals.keysToLabels = function (schema, keys) {
         return keys;
     }
 
-    const findNestedLabel = function (key) {
-
-        const [parentKey, ...parts] = key.split('.');
-        const childKeys = parts.join('.');
-        const matchingChild = children.find((child) => child.key === parentKey);
-        const label = matchingChild ? internals.keysToLabels(matchingChild.schema, childKeys) : key;
-
-        return !key.endsWith(label) ? label : key;
-    };
-
     const findLabel = function (key) {
 
-        if (key.includes('.')) {
-            return findNestedLabel(key);
-        }
-        const matchingChild = children.find((child) => child.key === key);
-        return matchingChild ? matchingChild.schema._getLabel(key) : key;
+        const matchingChild = schema._currentJoi.reach(schema, key);
+        return matchingChild ? matchingChild._getLabel(key) : key;
     };
 
     if (Array.isArray(keys)) {
-        return [].concat(keys.map(findLabel));
+        return keys.map(findLabel);
     }
 
     return findLabel(keys);

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -765,14 +765,26 @@ internals.keysToLabels = function (schema, keys) {
         return keys;
     }
 
+    const findNestedLabel = function (key) {
+
+        const [parentKey, ...parts] = key.split('.');
+        const childKeys = parts.join('.');
+        const childSchema = children.find((child) => child.key === parentKey);
+        const label = internals.keysToLabels(childSchema.schema, childKeys);
+        return key.endsWith(label) ? key : label;
+    };
+
     const findLabel = function (key) {
 
+        if (key.includes('.')) {
+            return findNestedLabel(key);
+        }
         const matchingChild = children.find((child) => child.key === key);
         return matchingChild ? matchingChild.schema._getLabel(key) : key;
     };
 
     if (Array.isArray(keys)) {
-        return keys.map(findLabel);
+        return [].concat(keys.map(findLabel));
     }
 
     return findLabel(keys);

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -769,9 +769,10 @@ internals.keysToLabels = function (schema, keys) {
 
         const [parentKey, ...parts] = key.split('.');
         const childKeys = parts.join('.');
-        const childSchema = children.find((child) => child.key === parentKey);
-        const label = internals.keysToLabels(childSchema.schema, childKeys);
-        return key.endsWith(label) ? key : label;
+        const matchingChild = children.find((child) => child.key === parentKey);
+        const label = matchingChild ? internals.keysToLabels(matchingChild.schema, childKeys) : key;
+
+        return !key.endsWith(label) ? label : key;
     };
 
     const findLabel = function (key) {

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2219,7 +2219,7 @@ describe('object', () => {
             }]);
         });
 
-        it('should apply labels without any peer', () => {
+        it('should apply labels without any nested peers', () => {
 
             const schema = Joi.object({
                 a: Joi.number().label('first'),
@@ -2240,7 +2240,7 @@ describe('object', () => {
             }] );
         });
 
-        it('should apply labels with too many peers', () => {
+        it('should apply labels with too many nested peers', () => {
 
             const schema = Joi.object({
                 a: Joi.number().label('first'),
@@ -2457,6 +2457,30 @@ describe('object', () => {
                         presentWithLabels: ['first'],
                         missing: ['b.c'],
                         missingWithLabels: ['second'],
+                        label: 'value',
+                        key: undefined
+                    }
+            }]);
+        });
+
+        it('should apply labels with invalid nested peers', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).and('a', 'c.d');
+            const error = schema.validate({ a: 1, b: { d: 1 } }).error;
+            expect(error).to.be.an.error('"value" contains [first] without its required peers [c.d]');
+            expect(error.details).to.equal([{
+                message: '"value" contains [first] without its required peers [c.d]',
+                path: [],
+                type: 'object.and',
+                context:
+                    {
+                        present: ['a'],
+                        presentWithLabels: ['first'],
+                        missing: ['c.d'],
+                        missingWithLabels: ['c.d'],
                         label: 'value',
                         key: undefined
                     }

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1967,6 +1967,29 @@ describe('object', () => {
         });
     });
 
+    it('should apply labels with nested objects', () => {
+
+        const schema = Joi.object({
+            a: Joi.number().label('first'),
+            b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+        }).with('a', ['b.c']);
+        const error = schema.validate({ a: 1 , b: { d: 2 } }).error;
+        expect(error).to.be.an.error('"first" missing required peer "second"');
+        expect(error.details).to.equal([{
+            message: '"first" missing required peer "second"',
+            path: ['a'],
+            type: 'object.with',
+            context: {
+                main: 'a',
+                mainWithLabel: 'first',
+                peer: 'b.c',
+                peerWithLabel: 'second',
+                label: 'a',
+                key: 'a'
+            }
+        }]);
+    });
+
     describe('without()', () => {
 
         it('should throw an error when a parameter is not a string', () => {
@@ -2076,6 +2099,29 @@ describe('object', () => {
                 }
             }]);
         });
+
+        it('should apply labels with nested objects', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).without('a', ['b.c']);
+            const error = schema.validate({ a: 1, b: { c: 'c' } }).error;
+            expect(error).to.be.an.error('"first" conflict with forbidden peer "second"');
+            expect(error.details).to.equal([{
+                message: '"first" conflict with forbidden peer "second"',
+                path: ['a'],
+                type: 'object.without',
+                context: {
+                    main: 'a',
+                    mainWithLabel: 'first',
+                    peer: 'b.c',
+                    peerWithLabel: 'second',
+                    label: 'a',
+                    key: 'a'
+                }
+            }]);
+        });
     });
 
     describe('xor()', () => {
@@ -2169,6 +2215,48 @@ describe('object', () => {
                     peersWithLabels: ['a', 'b.c'],
                     key: undefined,
                     label: 'value'
+                }
+            }]);
+        });
+
+        it('should apply labels without any peer', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).xor('a', 'b.c');
+            const error = schema.validate({}).error;
+            expect(error).to.be.an.error('"value" must contain at least one of [first, second]');
+            expect(error.details).to.equal([{
+                message: '"value" must contain at least one of [first, second]',
+                path: [],
+                type: 'object.missing',
+                context: {
+                    peers: ['a', 'b.c'],
+                    peersWithLabels: ['first', 'second'],
+                    label: 'value',
+                    key: undefined
+                }
+            }] );
+        });
+
+        it('should apply labels with too many peers', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).xor('a', 'b.c');
+            const error = schema.validate({ a: 1, b: { c: 'c' } }).error;
+            expect(error).to.be.an.error('"value" contains a conflict between exclusive peers [first, second]');
+            expect(error.details).to.equal([{
+                message: '"value" contains a conflict between exclusive peers [first, second]',
+                path: [],
+                type: 'object.xor',
+                context: {
+                    peers: ['a', 'b.c'],
+                    peersWithLabels: ['first', 'second'],
+                    label: 'value',
+                    key: undefined
                 }
             }]);
         });
@@ -2270,6 +2358,28 @@ describe('object', () => {
                 }
             }]);
         });
+
+        it('should apply labels with nested objects', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).or('a', 'b.c');
+            const error = schema.validate({}).error;
+            expect(error).to.be.an.error('"value" must contain at least one of [first, second]');
+            expect(error.details).to.equal([{
+                message: '"value" must contain at least one of [first, second]',
+                path: [],
+                type: 'object.missing',
+                context:
+                    {
+                        peers: ['a', 'b.c'],
+                        peersWithLabels: ['first', 'second'],
+                        label: 'value',
+                        key: undefined
+                    }
+            }]);
+        });
     });
 
     describe('and()', () => {
@@ -2328,6 +2438,30 @@ describe('object', () => {
                 }
             }]);
         });
+
+        it('should apply labels with nested objects', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).and('a', 'b.c');
+            const error = schema.validate({ a: 1 }).error;
+            expect(error).to.be.an.error('"value" contains [first] without its required peers [second]');
+            expect(error.details).to.equal([{
+                message: '"value" contains [first] without its required peers [second]',
+                path: [],
+                type: 'object.and',
+                context:
+                    {
+                        present: ['a'],
+                        presentWithLabels: ['first'],
+                        missing: ['b.c'],
+                        missingWithLabels: ['second'],
+                        label: 'value',
+                        key: undefined
+                    }
+            }]);
+        });
     });
 
     describe('nand()', () => {
@@ -2382,6 +2516,29 @@ describe('object', () => {
                     peersWithLabels: ['b.c'],
                     key: undefined,
                     label: 'value'
+                }
+            }]);
+        });
+
+        it('should apply labels with nested objects', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().label('first'),
+                b: Joi.object({ c: Joi.string().label('second'), d: Joi.number() })
+            }).nand('a', 'b.c');
+            const error = schema.validate({ a: 1, b: { c: 'c' } }).error;
+            expect(error).to.be.an.error('"first" must not exist simultaneously with [second]');
+            expect(error.details).to.equal([{
+                message: '"first" must not exist simultaneously with [second]',
+                path: [],
+                type: 'object.nand',
+                context: {
+                    main: 'a',
+                    mainWithLabel: 'first',
+                    peers: ['b.c'],
+                    peersWithLabels: ['second'],
+                    label: 'value',
+                    key: undefined
                 }
             }]);
         });


### PR DESCRIPTION
```
> lab -t 100 -a code -L



  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  .......................

1123 tests complete
Test duration: 3341 ms
Assertions count: 21153 (verbosity: 18.84)
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```